### PR TITLE
Improve navbar and lint cleanup

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -2,7 +2,9 @@
 import React from 'react';
 import '../assets/styles/App.css';
 
-type AboutSectionProps = {};
+// The component has no props; using `Record<string, never>` avoids the
+// no-empty-object-type lint error from typescript-eslint.
+type AboutSectionProps = Record<string, never>;
 
 const AboutSection: React.FC<AboutSectionProps> = () => {
   return (

--- a/src/components/EventsSection.tsx
+++ b/src/components/EventsSection.tsx
@@ -2,7 +2,9 @@
 import React from 'react';
 import '../assets/styles/App.css';
 
-type EventsSectionProps = {};
+// This component does not accept props. Using `Record<string, never>` keeps
+// the type strict without triggering the no-empty-object-type rule.
+type EventsSectionProps = Record<string, never>;
 
 const EventsSection: React.FC<EventsSectionProps> = () => {
   return (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,17 +1,47 @@
 // src/components/Navbar.tsx
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-const Navbar = () => (
-  <nav className="bg-gray-800 p-4 text-white">
-    <div className="flex justify-between">
-      <Link to="/">FEBS</Link>
-      <div>
-        <Link to="/team" className="px-4">Team</Link>
-        <Link to="/resources" className="px-4">Resources</Link>
+/**
+ * Navigation bar with a simple dark mode toggle.
+ */
+const Navbar = () => {
+  const [isDark, setIsDark] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem('theme') === 'dark';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDark) {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  }, [isDark]);
+
+  return (
+    <nav className="bg-white dark:bg-gray-800 p-4 text-gray-800 dark:text-white">
+      <div className="flex justify-between items-center">
+        <Link to="/">FEBS</Link>
+        <div className="flex items-center gap-4">
+          <Link to="/team" className="px-2">
+            Team
+          </Link>
+          <Link to="/resources" className="px-2">
+            Resources
+          </Link>
+          <button
+            onClick={() => setIsDark(!isDark)}
+            className="border px-2 py-1 rounded-md"
+          >
+            {isDark ? 'Light' : 'Dark'}
+          </button>
+        </div>
       </div>
-    </div>
-  </nav>
-);
+    </nav>
+  );
+};
 
 export default Navbar;

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Card, CardHeader, CardContent } from '@/components/ui/card.js';
 import { Button } from '@/components/ui/button.js';
-import { LinkedinIcon, TwitterIcon, MailIcon, GithubIcon, ExternalLinkIcon } from 'lucide-react';
+import { LinkedinIcon, TwitterIcon, MailIcon, ExternalLinkIcon } from 'lucide-react';
 import { LucideProps } from 'lucide-react';
 
 type TeamMember = {
@@ -349,14 +349,6 @@ const Team: React.FC = () => {
     };
 
     
-    const colorPalette = {
-        primary: '#2ecc71',
-        secondary: '#3498db',
-        tertiary: '#1abc9c',
-        text: '#ffffff',
-        background: '#000000',
-        buttonHover: '#27ae60'
-    };
 
     
     


### PR DESCRIPTION
## Summary
- add simple dark mode toggle in the Navbar
- clean up About and Events sections to satisfy lint rules
- remove unused code from Team page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876a9ed8238833383df5c494979ea5d